### PR TITLE
fix build breakage due to protolude `toS` changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-9.11
+      - image: fpco/stack-build:lts
     steps:
       - checkout
       - restore_cache:

--- a/cmd/interop-entrypoint/Main.hs
+++ b/cmd/interop-entrypoint/Main.hs
@@ -16,7 +16,8 @@
 
 module Main (main) where
 
-import Protolude hiding (group)
+import Protolude hiding (group, toS)
+import Protolude.Conv (toS)
 
 import Crypto.Hash (SHA256(..))
 import Data.ByteArray.Encoding (convertFromBase, convertToBase, Base(Base16))

--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ default-extensions:
 
 dependencies:
   - base >= 4.9 && < 5
-  - protolude >= 0.2
+  - protolude >= 0.3
 
 executables:
   haskell-spake2-interop-entrypoint:

--- a/spake2.cabal
+++ b/spake2.cabal
@@ -1,4 +1,6 @@
--- This file has been generated from package.yaml by hpack version 0.17.1.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -16,11 +18,8 @@ maintainer:     Jonathan M. Lange <jml@mumak.net>
 license:        Apache
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
-
 extra-source-files:
     CHANGELOG.md
-
 data-files:
     tests/python/spake2_exchange.py
 
@@ -34,11 +33,11 @@ library
   default-extensions: NoImplicitPrelude OverloadedStrings
   ghc-options: -Wall -Wno-type-defaults
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
+      base >=4.9 && <5
     , bytestring
     , cryptonite
     , memory
+    , protolude >=0.3
   exposed-modules:
       Crypto.Spake2
       Crypto.Spake2.Group
@@ -47,20 +46,24 @@ library
       Crypto.Spake2.Groups.IntegerGroup
       Crypto.Spake2.Math
       Crypto.Spake2.Util
+  other-modules:
+      Paths_spake2
   default-language: Haskell2010
 
 executable haskell-spake2-interop-entrypoint
   main-is: Main.hs
+  other-modules:
+      Paths_spake2
   hs-source-dirs:
       cmd/interop-entrypoint
   default-extensions: NoImplicitPrelude OverloadedStrings
   ghc-options: -Wall -Wno-type-defaults -threaded
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
+      base >=4.9 && <5
     , cryptonite
     , memory
     , optparse-applicative
+    , protolude >=0.3
     , spake2
   default-language: Haskell2010
 
@@ -72,14 +75,14 @@ test-suite tasty
   default-extensions: NoImplicitPrelude OverloadedStrings
   ghc-options: -Wall -Wno-type-defaults
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
+      QuickCheck
     , aeson
+    , base >=4.9 && <5
     , bytestring
     , cryptonite
     , memory
     , process
-    , QuickCheck
+    , protolude >=0.3
     , spake2
     , tasty
     , tasty-hspec
@@ -87,4 +90,5 @@ test-suite tasty
       Groups
       Integration
       Spake2
+      Paths_spake2
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
   - .
 
 extra-deps:
-  - protolude-0.2
+  - protolude-0.3.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.11
+resolver: lts-16.17
 
 packages:
   - .

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -1,6 +1,7 @@
 module Integration (tests) where
 
-import Protolude hiding (stdin, stdout)
+import Protolude hiding (stdin, stdout, toS)
+import Protolude.Conv (toS)
 
 import Crypto.Hash (SHA256(..))
 import Data.ByteArray.Encoding (convertFromBase, convertToBase, Base(Base16))


### PR DESCRIPTION
Fixes #19.

Protolude 0.3.0 switched to a different version of `toS` that is
non-partial and so removed a bunch of cases that `toS` supported.

This PR switches to the old `toS` that has been left in the Conv
module. From what I understand, newer Protolude versions may 
see more changes in `toS`, so will wait for it to stabilize before 
making changes across the code.